### PR TITLE
Add artifact step to broken links workflow

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -49,4 +49,10 @@ jobs:
         with:
           fail: true
           # removed md files that include liquid tags
-          args: --user-agent 'curl/7.54' --exclude-path README.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path _posts/2018-12-22-distill.md --exclude-path _posts/2023-04-24-videos.md --verbose --no-progress './**/*.md' './**/*.html'
+          args: --user-agent 'curl/7.54' --exclude-path README.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path _posts/2018-12-22-distill.md --exclude-path _posts/2023-04-24-videos.md --output lychee/out.md --verbose --no-progress './**/*.md' './**/*.html'
+
+      - name: Upload link-check report
+        uses: actions/upload-artifact@v3
+        with:
+          name: lychee-report
+          path: lychee/out.md


### PR DESCRIPTION
## Summary
- save lychee link checker results to `lychee/out.md`
- upload link-check report as workflow artifact

## Testing
- `pip install pre-commit` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683facf8b2e88328ab07d4f567c658ea