### PR TITLE
Fix relative url resolution for downloads

### DIFF
--- a/_plugins/download-3rd-party.rb
+++ b/_plugins/download-3rd-party.rb
@@ -25,8 +25,8 @@ Jekyll::Hooks.register :site, :after_init do |site|
       # verify if the file is of the correct type
       if file_name.end_with?(*file_types)
         # fix the url if it is not an absolute url
-        unless url.start_with?('https://')
-          url = URI.join(url, url).to_s
+        unless url.start_with?('https://', 'http://')
+          url = URI.join(config['url'], url).to_s
         end
 
         # download the file


### PR DESCRIPTION
## Summary
- ensure relative URLs are resolved against the site URL in `download_and_change_rule_set_url`

## Testing
- `pre-commit` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_683facf9ca588328b7ea0efb1eceb380