### PR TITLE
Add interactive Task Board page with drag/drop, persistence, dark mode, and productivity features

### DIFF
--- a/_pages/game.md
+++ b/_pages/game.md
@@ -1,16 +1,36 @@
 ---
 layout: default
-title: "Guess the Number Game"
+title: "Task Board"
 permalink: /game/
 nav: true
 nav_order: 99
 ---
 
-<h1>Guess the Number Game</h1>
-<p>Try to guess the random number between 1 and 100.</p>
-<input type="number" id="guessInput" min="1" max="100" />
-<button onclick="makeGuess()">Guess</button>
-<p id="result"></p>
+<link rel="stylesheet" href="{{ '/assets/css/task-board.css' | relative_url }}" />
 
-<script src="{{ '/assets/js/guess-the-number.js' | relative_url }}"></script>
+<div class="task-board" id="taskBoard">
+  <header class="task-board__header">
+    <h1>Task Board</h1>
+    <div class="task-board__controls">
+      <button id="newTaskBtn" type="button" title="Shortcut: N">+ New Task</button>
+      <button id="darkModeBtn" type="button">Toggle dark mode</button>
+    </div>
+  </header>
 
+  <div class="task-board__toolbar">
+    <input id="searchInput" type="text" placeholder="Search tasks, notes, tags..." />
+    <div class="progress-wrap">
+      <span id="progressLabel">0% complete</span>
+      <div class="progress-track"><div id="progressFill" class="progress-fill"></div></div>
+    </div>
+  </div>
+
+  <ul id="taskList" class="task-list" aria-label="Task list"></ul>
+</div>
+
+<div id="undoToast" class="undo-toast" role="status" aria-live="polite">
+  <span>Task deleted.</span>
+  <button id="undoDeleteBtn" type="button">Undo</button>
+</div>
+
+<script src="{{ '/assets/js/task-board.js' | relative_url }}"></script>

--- a/assets/css/task-board.css
+++ b/assets/css/task-board.css
@@ -1,0 +1,208 @@
+:root {
+  --bg: #fff8ef;
+  --panel: #fff;
+  --text: #3a2f2a;
+  --muted: #7a6961;
+  --accent: #e4803a;
+  --ok: #2f8f4e;
+  --danger: #d65454;
+  --border: #efd9c8;
+}
+
+.task-board.dark {
+  --bg: #1b1f28;
+  --panel: #242a36;
+  --text: #eef2f8;
+  --muted: #98a4b6;
+  --accent: #f3a15f;
+  --ok: #46bf78;
+  --danger: #ff7b7b;
+  --border: #394457;
+}
+
+.task-board {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
+}
+
+.task-board input,
+.task-board button,
+.task-board textarea {
+  font: inherit;
+}
+
+.task-board__header,
+.task-board__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.task-board button {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.35rem 0.65rem;
+  background: var(--panel);
+  color: var(--text);
+}
+
+#searchInput,
+.inline-input,
+.notes {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--text);
+  padding: 0.45rem 0.6rem;
+}
+
+.progress-wrap {
+  min-width: 220px;
+}
+
+.progress-track {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  height: 12px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--accent), #f0cb62);
+  transition: width 0.25s ease;
+}
+
+.task-list,
+.subtask-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.task-item {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-top: 0.7rem;
+  padding: 0.6rem;
+  transition:
+    transform 0.2s ease,
+    opacity 0.2s ease,
+    background 0.2s ease;
+}
+
+.task-item.removing {
+  opacity: 0;
+  transform: translateX(18px);
+}
+
+.task-item.dragging {
+  opacity: 0.55;
+}
+
+.task-item.selected {
+  outline: 2px solid var(--accent);
+}
+
+.task-main {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.task-label {
+  cursor: text;
+}
+
+.task-item.completed .task-label {
+  text-decoration: line-through;
+  color: var(--muted);
+}
+
+.task-meta {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+}
+
+.due.overdue {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.tags {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  color: #fff;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.subtask-list {
+  margin-top: 0.5rem;
+  padding-left: 1rem;
+}
+
+.subtask-item {
+  margin-top: 0.4rem;
+}
+
+.task-tools {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.notes-wrap {
+  margin-top: 0.5rem;
+}
+
+.notes {
+  min-height: 70px;
+  resize: vertical;
+}
+
+.undo-toast {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #1f2732;
+  color: #fff;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.undo-toast.show {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}

--- a/assets/js/task-board.js
+++ b/assets/js/task-board.js
@@ -1,0 +1,356 @@
+(() => {
+  const STORAGE_KEY = "task-board-state-v1";
+  const COLORS = ["#e76f51", "#2a9d8f", "#457b9d", "#9b5de5", "#f4a261"];
+
+  const taskBoard = document.getElementById("taskBoard");
+  const taskList = document.getElementById("taskList");
+  const searchInput = document.getElementById("searchInput");
+  const newTaskBtn = document.getElementById("newTaskBtn");
+  const darkModeBtn = document.getElementById("darkModeBtn");
+  const progressFill = document.getElementById("progressFill");
+  const progressLabel = document.getElementById("progressLabel");
+  const undoToast = document.getElementById("undoToast");
+  const undoDeleteBtn = document.getElementById("undoDeleteBtn");
+
+  let state = loadState();
+  let selectedTaskId = null;
+  let undoBuffer = null;
+  let undoTimer = null;
+
+  function uid() {
+    return Math.random().toString(36).slice(2, 11);
+  }
+
+  function defaultTask(text = "New task") {
+    return {
+      id: uid(),
+      text,
+      completed: false,
+      dueDate: "",
+      notes: "",
+      showNotes: false,
+      tags: [],
+      subtasks: [],
+    };
+  }
+
+  function loadState() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { darkMode: false, search: "", tasks: [defaultTask("Welcome! Click me to rename")] };
+    }
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return { darkMode: false, search: "", tasks: [] };
+    }
+  }
+
+  function saveState() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+
+  function traverseTasks(visitor) {
+    state.tasks.forEach((task) => {
+      visitor(task, null, false);
+      task.subtasks.forEach((subtask) => visitor(subtask, task, true));
+    });
+  }
+
+  function findTask(taskId) {
+    for (const task of state.tasks) {
+      if (task.id === taskId) return { item: task, parent: null, isSubtask: false };
+      for (const sub of task.subtasks) {
+        if (sub.id === taskId) return { item: sub, parent: task, isSubtask: true };
+      }
+    }
+    return null;
+  }
+
+  function removeTask(taskId) {
+    const topIndex = state.tasks.findIndex((t) => t.id === taskId);
+    if (topIndex >= 0) return state.tasks.splice(topIndex, 1)[0];
+    for (const task of state.tasks) {
+      const subIndex = task.subtasks.findIndex((t) => t.id === taskId);
+      if (subIndex >= 0) return task.subtasks.splice(subIndex, 1)[0];
+    }
+    return null;
+  }
+
+  function insertTask(item, parentId, beforeId = null) {
+    const list = parentId ? findTask(parentId).item.subtasks : state.tasks;
+    if (!beforeId) {
+      list.push(item);
+      return;
+    }
+    const idx = list.findIndex((it) => it.id === beforeId);
+    if (idx === -1) list.push(item);
+    else list.splice(idx, 0, item);
+  }
+
+  function isOverdue(item) {
+    if (!item.dueDate || item.completed) return false;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const due = new Date(item.dueDate);
+    return due < today;
+  }
+
+  function updateProgress() {
+    let total = 0;
+    let done = 0;
+    traverseTasks((item) => {
+      total += 1;
+      if (item.completed) done += 1;
+    });
+    const pct = total === 0 ? 0 : Math.round((done / total) * 100);
+    progressFill.style.width = `${pct}%`;
+    progressLabel.textContent = `${pct}% complete`;
+  }
+
+  function addTag(item, rawTag) {
+    const tag = rawTag.trim();
+    if (!tag) return;
+    item.tags.push({ id: uid(), name: tag, color: COLORS[item.tags.length % COLORS.length] });
+  }
+
+  function showUndo(item, parentId, beforeId) {
+    undoBuffer = { item, parentId, beforeId };
+    undoToast.classList.add("show");
+    clearTimeout(undoTimer);
+    undoTimer = setTimeout(() => {
+      undoBuffer = null;
+      undoToast.classList.remove("show");
+    }, 5000);
+  }
+
+  function startInlineEdit(labelEl, item) {
+    const input = document.createElement("input");
+    input.className = "inline-input";
+    input.value = item.text;
+    labelEl.replaceWith(input);
+    input.focus();
+    input.select();
+
+    const commit = () => {
+      item.text = input.value.trim() || "Untitled task";
+      saveState();
+      render();
+    };
+
+    input.addEventListener("blur", commit, { once: true });
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") input.blur();
+      if (event.key === "Escape") render();
+    });
+  }
+
+  function renderTask(item, parent = null) {
+    const li = document.createElement("li");
+    li.className = `task-item ${item.completed ? "completed" : ""}`;
+    li.dataset.id = item.id;
+    li.draggable = true;
+    if (selectedTaskId === item.id) li.classList.add("selected");
+
+    li.innerHTML = `
+      <div class="task-main">
+        <input type="checkbox" ${item.completed ? "checked" : ""} aria-label="Toggle completion" />
+        <span class="task-label">${item.text}</span>
+        <button type="button" class="delete-btn">Delete</button>
+      </div>
+      <div class="task-meta">
+        <label>Due <input type="date" class="due-input" value="${item.dueDate || ""}" /></label>
+        <span class="due ${isOverdue(item) ? "overdue" : ""}">${isOverdue(item) ? "Overdue" : ""}</span>
+        <div class="tags"></div>
+      </div>
+      <div class="task-tools">
+        <button type="button" class="add-subtask-btn">+ Subtask</button>
+        <button type="button" class="toggle-notes-btn">${item.showNotes ? "Hide notes" : "Notes"}</button>
+        <input type="text" class="tag-input" placeholder="Add tag + Enter" />
+      </div>
+      <div class="notes-wrap" style="display:${item.showNotes ? "block" : "none"}">
+        <textarea class="notes" placeholder="Task notes...">${item.notes || ""}</textarea>
+      </div>
+    `;
+
+    const checkbox = li.querySelector('input[type="checkbox"]');
+    checkbox.addEventListener("change", () => {
+      item.completed = checkbox.checked;
+      saveState();
+      render();
+    });
+
+    const label = li.querySelector(".task-label");
+    label.addEventListener("click", () => startInlineEdit(label, item));
+
+    li.querySelector(".delete-btn").addEventListener("click", () => {
+      const parentId = parent ? parent.id : null;
+      const list = parent ? parent.subtasks : state.tasks;
+      const idx = list.findIndex((x) => x.id === item.id);
+      const beforeId = list[idx + 1]?.id || null;
+      const deleted = removeTask(item.id);
+      saveState();
+      showUndo(deleted, parentId, beforeId);
+      render();
+    });
+
+    li.querySelector(".due-input").addEventListener("change", (event) => {
+      item.dueDate = event.target.value;
+      saveState();
+      render();
+    });
+
+    li.querySelector(".add-subtask-btn").addEventListener("click", () => {
+      item.subtasks.push(defaultTask("New subtask"));
+      saveState();
+      render();
+    });
+
+    li.querySelector(".toggle-notes-btn").addEventListener("click", () => {
+      item.showNotes = !item.showNotes;
+      saveState();
+      render();
+    });
+
+    li.querySelector(".notes").addEventListener("input", (event) => {
+      item.notes = event.target.value;
+      saveState();
+    });
+
+    li.querySelector(".tag-input").addEventListener("keydown", (event) => {
+      if (event.key !== "Enter") return;
+      addTag(item, event.target.value);
+      event.target.value = "";
+      saveState();
+      render();
+    });
+
+    const tagWrap = li.querySelector(".tags");
+    item.tags.forEach((tag) => {
+      const chip = document.createElement("span");
+      chip.className = "tag";
+      chip.style.background = tag.color;
+      chip.textContent = tag.name;
+      tagWrap.appendChild(chip);
+    });
+
+    li.addEventListener("click", () => {
+      selectedTaskId = item.id;
+      render();
+    });
+
+    li.addEventListener("dragstart", (event) => {
+      li.classList.add("dragging");
+      event.dataTransfer.setData("text/plain", item.id);
+    });
+    li.addEventListener("dragend", () => li.classList.remove("dragging"));
+
+    return li;
+  }
+
+  function setupDropZone(ul, parentId = null) {
+    ul.addEventListener("dragover", (event) => {
+      event.preventDefault();
+      const target = event.target.closest(".task-item");
+      if (!target || target.parentElement !== ul) return;
+      const rect = target.getBoundingClientRect();
+      const before = event.clientY < rect.top + rect.height / 2;
+      ul.dataset.beforeId = before ? target.dataset.id : target.nextElementSibling?.dataset.id || "";
+    });
+
+    ul.addEventListener("drop", (event) => {
+      event.preventDefault();
+      const draggedId = event.dataTransfer.getData("text/plain");
+      if (!draggedId) return;
+      const found = findTask(draggedId);
+      if (!found) return;
+      const moved = removeTask(draggedId);
+      const beforeId = ul.dataset.beforeId || null;
+      insertTask(moved, parentId, beforeId);
+      saveState();
+      render();
+    });
+  }
+
+  function render() {
+    taskBoard.classList.toggle("dark", state.darkMode);
+    searchInput.value = state.search || "";
+    taskList.innerHTML = "";
+
+    state.tasks.forEach((task) => {
+      const haystack = `${task.text} ${task.notes} ${task.tags.map((t) => t.name).join(" ")}`.toLowerCase();
+      const match = !state.search || haystack.includes(state.search.toLowerCase());
+      if (!match) return;
+
+      const li = renderTask(task);
+      const subList = document.createElement("ul");
+      subList.className = "subtask-list";
+      task.subtasks.forEach((sub) => subList.appendChild(renderTask(sub, task)));
+      setupDropZone(subList, task.id);
+      li.appendChild(subList);
+      taskList.appendChild(li);
+    });
+
+    setupDropZone(taskList);
+    updateProgress();
+  }
+
+  newTaskBtn.addEventListener("click", () => {
+    state.tasks.unshift(defaultTask());
+    selectedTaskId = state.tasks[0].id;
+    saveState();
+    render();
+  });
+
+  darkModeBtn.addEventListener("click", () => {
+    state.darkMode = !state.darkMode;
+    saveState();
+    render();
+  });
+
+  searchInput.addEventListener("input", (event) => {
+    state.search = event.target.value;
+    saveState();
+    render();
+  });
+
+  undoDeleteBtn.addEventListener("click", () => {
+    if (!undoBuffer) return;
+    insertTask(undoBuffer.item, undoBuffer.parentId, undoBuffer.beforeId);
+    undoBuffer = null;
+    undoToast.classList.remove("show");
+    saveState();
+    render();
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (["INPUT", "TEXTAREA"].includes(document.activeElement?.tagName)) return;
+    if (event.key.toLowerCase() === "n") {
+      newTaskBtn.click();
+    }
+
+    const flat = [];
+    traverseTasks((item) => flat.push(item));
+    const selectedIndex = flat.findIndex((t) => t.id === selectedTaskId);
+
+    if (event.key === "ArrowDown" && flat.length) {
+      selectedTaskId = flat[Math.min(selectedIndex + 1, flat.length - 1)]?.id || flat[0].id;
+      render();
+    }
+    if (event.key === "ArrowUp" && flat.length) {
+      selectedTaskId = flat[Math.max(selectedIndex - 1, 0)]?.id || flat[0].id;
+      render();
+    }
+    if (event.code === "Space" && selectedTaskId) {
+      event.preventDefault();
+      const selected = findTask(selectedTaskId)?.item;
+      if (selected) {
+        selected.completed = !selected.completed;
+        saveState();
+        render();
+      }
+    }
+  });
+
+  render();
+})();


### PR DESCRIPTION
### Motivation
- Replace the simple `/game/` placeholder with a fully-featured task board to provide local task management directly on the site. 
- Provide common productivity UX: drag & drop reordering, due dates with overdue state, tags, inline editing, and undo for destructive actions. 
- Persist user data locally and support keyboard/navigation shortcuts and a pleasant light/dark theme to improve day-to-day usability.

### Description
- Replaced `_pages/game.md` page content with a Task Board mount and controls and added `assets/css/task-board.css` for warm light / dark theme styling and card/animation styles. 
- Added `assets/js/task-board.js` which implements the board state, HTML5 drag-and-drop for tasks and subtasks, localStorage persistence under the key `task-board-state-v1`, inline editing, due-date + overdue detection, tag chips, expandable notes, and progress calculation. 
- Implemented keyboard shortcuts and navigation (`N` to create, `ArrowUp`/`ArrowDown` to move selection, `Space` to toggle completion), and a deletion undo flow using a temporary undo buffer and toast with `aria-live` for accessibility. 
- Minor UX helpers: color-cycling tags, selection state, subtle transitions/animations, and search filtering; all UI pieces wired into the single-page JS renderer.

### Testing
- Ran `node --check assets/js/task-board.js` to validate JS syntax and it succeeded. 
- Ran `npx prettier --check _pages/game.md assets/css/task-board.css assets/js/task-board.js` (after formatting with `npx prettier --write`) and the files passed formatting checks. 
- Attempted to run `bundle exec jekyll serve` to preview in the site context but it failed in this environment due to missing bundler/Jekyll executables. 
- Served a static preview via `python3 -m http.server` and executed a Playwright script to load the preview and capture a screenshot, which completed and produced a UI artifact confirming the integration visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0479097908328b5c79157d6a1e80a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced number-guessing game with a task board application
  * Task creation, editing, completion tracking, and dark mode toggle
  * Search and filter functionality for tasks
  * Metadata support including due dates, notes, and tags
  * Subtask management and drag-and-drop reordering
  * Undo support for deletions and progress indicator
  * Keyboard shortcuts for efficient navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->